### PR TITLE
feat: dcl spring bone extension

### DIFF
--- a/Runtime/Scripts/DclGameObjectInstantiator.cs
+++ b/Runtime/Scripts/DclGameObjectInstantiator.cs
@@ -20,30 +20,8 @@ namespace GLTFast
         public override void EndScene(uint[] rootNodeIndices)
         {
             base.EndScene(rootNodeIndices);
-            
-            AddSpringBoneJoints();
-        }
 
-        void AddSpringBoneJoints()
-        {
-            var nodes = m_Gltf.GetSourceRoot()?.nodes;
-            if (nodes == null) return;
-
-            for (uint i = 0; i < nodes.Length; i++)
-            {
-                var springBone = nodes[i].extensions?.DCL_spring_bone_joint;
-                if (springBone == null) continue;
-
-                if (!m_Nodes.TryGetValue(i, out var go)) continue;
-
-                var component = go.AddComponent<SpringBoneJointComponent>();
-                component.Stiffness = springBone.stiffness;
-                component.Drag = springBone.drag;
-                component.GravityDir = springBone.GravityDir;
-                component.GravityPower = springBone.gravityPower;
-                component.HitRadius = springBone.hitRadius;
-                component.IsRoot = springBone.isRoot;
-            }
+            SpringBoneUtils.ApplySpringBoneJoints(m_Gltf, m_Nodes);
         }
     }
 }

--- a/Runtime/Scripts/DclGameObjectInstantiator.cs
+++ b/Runtime/Scripts/DclGameObjectInstantiator.cs
@@ -1,0 +1,49 @@
+using GLTFast.Logging;
+using UnityEngine;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Extends <see cref="GameObjectInstantiator"/> with DCL-specific extension handling,
+    /// such as spring bone joints.
+    /// </summary>
+    public class DclGameObjectInstantiator : GameObjectInstantiator
+    {
+        public DclGameObjectInstantiator(
+            IGltfReadable gltf,
+            Transform parent,
+            ICodeLogger logger = null,
+            InstantiationSettings settings = null) : base(gltf, parent, logger, settings)
+        {
+        }
+
+        public override void EndScene(uint[] rootNodeIndices)
+        {
+            base.EndScene(rootNodeIndices);
+            
+            AddSpringBoneJoints();
+        }
+
+        void AddSpringBoneJoints()
+        {
+            var nodes = m_Gltf.GetSourceRoot()?.nodes;
+            if (nodes == null) return;
+
+            for (uint i = 0; i < nodes.Length; i++)
+            {
+                var springBone = nodes[i].extensions?.DCL_spring_bone_joint;
+                if (springBone == null) continue;
+
+                if (!m_Nodes.TryGetValue(i, out var go)) continue;
+
+                var component = go.AddComponent<SpringBoneJointComponent>();
+                component.Stiffness = springBone.stiffness;
+                component.Drag = springBone.drag;
+                component.GravityDir = springBone.GravityDir;
+                component.GravityPower = springBone.gravityPower;
+                component.HitRadius = springBone.hitRadius;
+                component.IsRoot = springBone.isRoot;
+            }
+        }
+    }
+}

--- a/Runtime/Scripts/DclGameObjectInstantiator.cs.meta
+++ b/Runtime/Scripts/DclGameObjectInstantiator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2702be323ea01ed43b19c9d11ee9201b

--- a/Runtime/Scripts/Extensions.cs
+++ b/Runtime/Scripts/Extensions.cs
@@ -57,6 +57,10 @@ namespace GLTFast
         /// <see href="https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_texture_transform/README.md">KHR_texture_transform</see> glTF extension
         /// </summary>
         TextureTransform,
+        /// <summary>
+        /// DCL_spring_bone_joint glTF extension for spring bone simulation
+        /// </summary>
+        SpringBoneJoint,
     }
 
     /// <summary>
@@ -104,6 +108,10 @@ namespace GLTFast
         /// <see href="https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_lights_punctual">KHR_lights_punctual</see> glTF extension
         /// </summary>
         public const string LightsPunctual = "KHR_lights_punctual";
+        /// <summary>
+        /// DCL_spring_bone_joint glTF extension
+        /// </summary>
+        public const string SpringBoneJoint = "DCL_spring_bone_joint";
 
         /// <summary>
         /// Returns the official name of the glTF extension
@@ -132,6 +140,8 @@ namespace GLTFast
                     return TextureBasisUniversal;
                 case Extension.TextureTransform:
                     return TextureTransform;
+                case Extension.SpringBoneJoint:
+                    return SpringBoneJoint;
                 default:
                     return null;
             }

--- a/Runtime/Scripts/GltfImport.cs
+++ b/Runtime/Scripts/GltfImport.cs
@@ -124,6 +124,7 @@ namespace GLTFast
             ExtensionName.MaterialsTransmission,
             ExtensionName.MeshGPUInstancing,
             ExtensionName.LightsPunctual,
+            ExtensionName.SpringBoneJoint,
         };
 
         static IDeferAgent s_DefaultDeferAgent;

--- a/Runtime/Scripts/JsonParser.cs
+++ b/Runtime/Scripts/JsonParser.cs
@@ -211,9 +211,15 @@ namespace GLTFast
                         {
                             e.KHR_lights_punctual = null;
                         }
+                        // Check if spring bone joint extension is valid
+                        if ((e.DCL_spring_bone_joint?.version ?? -1) < 0)
+                        {
+                            e.DCL_spring_bone_joint = null;
+                        }
                         // Unset `extension` if none of them was valid
                         if (e.EXT_mesh_gpu_instancing == null &&
-                            e.KHR_lights_punctual == null)
+                            e.KHR_lights_punctual == null &&
+                            e.DCL_spring_bone_joint == null)
                         {
                             root.nodes[i].extensions = null;
                         }

--- a/Runtime/Scripts/Schema/Node.cs
+++ b/Runtime/Scripts/Schema/Node.cs
@@ -141,6 +141,8 @@ namespace GLTFast.Schema
         public MeshGpuInstancing EXT_mesh_gpu_instancing;
         /// <inheritdoc cref="LightsPunctual"/>
         public NodeLightsPunctual KHR_lights_punctual;
+        /// <inheritdoc cref="SpringBoneJoint"/>
+        public SpringBoneJoint DCL_spring_bone_joint;
 
         // Whenever an extension is added, the JsonParser
         // (specifically step four of JsonParser.ParseJson)
@@ -159,6 +161,11 @@ namespace GLTFast.Schema
             {
                 writer.AddProperty("KHR_lights_punctual");
                 KHR_lights_punctual.GltfSerialize(writer);
+            }
+            if (DCL_spring_bone_joint != null)
+            {
+                writer.AddProperty("DCL_spring_bone_joint");
+                DCL_spring_bone_joint.GltfSerialize(writer);
             }
             writer.Close();
         }

--- a/Runtime/Scripts/Schema/SpringBoneJoint.cs
+++ b/Runtime/Scripts/Schema/SpringBoneJoint.cs
@@ -1,0 +1,88 @@
+using System;
+using UnityEngine;
+
+namespace GLTFast.Schema
+{
+
+    /// <summary>
+    /// DCL spring bone joint extension data.
+    /// Adds spring-bone simulation parameters to a node/bone.
+    /// </summary>
+    [Serializable]
+    public class SpringBoneJoint
+    {
+
+        /// <summary>
+        /// Extension version
+        /// </summary>
+        public int version = -1;
+
+        /// <summary>
+        /// Stiffness force for returning to the initial pose
+        /// </summary>
+        public float stiffness;
+
+        /// <summary>
+        /// Drag force for damping the spring motion
+        /// </summary>
+        public float drag;
+
+        /// <summary>
+        /// Gravity direction as [x, y, z]
+        /// </summary>
+        public float[] gravityDir;
+
+        /// <summary>
+        /// Gravity power applied to this joint
+        /// </summary>
+        public float gravityPower;
+
+        /// <summary>
+        /// Hit radius for collision detection
+        /// </summary>
+        public float hitRadius;
+
+        /// <summary>
+        /// Whether this joint is the root of a spring bone chain
+        /// </summary>
+        public bool isRoot;
+
+        /// <summary>
+        /// Gravity direction as a Unity Vector3
+        /// </summary>
+        public Vector3 GravityDir
+        {
+            get
+            {
+                if (gravityDir != null && gravityDir.Length >= 3)
+                {
+                    return new Vector3(gravityDir[0], gravityDir[1], gravityDir[2]);
+                }
+                return Vector3.down;
+            }
+            set => gravityDir = new[] { value.x, value.y, value.z };
+        }
+
+        internal void GltfSerialize(JsonWriter writer)
+        {
+            writer.AddObject();
+            if (version >= 0)
+            {
+                writer.AddProperty("version", version);
+            }
+            writer.AddProperty("stiffness", stiffness);
+            writer.AddProperty("drag", drag);
+            if (gravityDir != null)
+            {
+                writer.AddArrayProperty("gravityDir", gravityDir);
+            }
+            writer.AddProperty("gravityPower", gravityPower);
+            writer.AddProperty("hitRadius", hitRadius);
+            if (isRoot)
+            {
+                writer.AddProperty("isRoot", true);
+            }
+            writer.Close();
+        }
+    }
+}

--- a/Runtime/Scripts/Schema/SpringBoneJoint.cs.meta
+++ b/Runtime/Scripts/Schema/SpringBoneJoint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 001d307dfb32928449959b2f2cd6907e

--- a/Runtime/Scripts/SpringBoneJointComponent.cs
+++ b/Runtime/Scripts/SpringBoneJointComponent.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Holds DCL spring bone joint data parsed from a glTF node extension.
+    /// </summary>
+    public class SpringBoneJointComponent : MonoBehaviour
+    {
+        public float Stiffness { get; set; }
+        public float Drag { get; set; }
+        public Vector3 GravityDir { get; set; }
+        public float GravityPower { get; set; }
+        public float HitRadius { get; set; }
+        public bool IsRoot { get; set; }
+    }
+}

--- a/Runtime/Scripts/SpringBoneJointComponent.cs
+++ b/Runtime/Scripts/SpringBoneJointComponent.cs
@@ -7,11 +7,11 @@ namespace GLTFast
     /// </summary>
     public class SpringBoneJointComponent : MonoBehaviour
     {
-        public float Stiffness { get; set; }
-        public float Drag { get; set; }
-        public Vector3 GravityDir { get; set; }
-        public float GravityPower { get; set; }
-        public float HitRadius { get; set; }
-        public bool IsRoot { get; set; }
+        [field: SerializeField] public float Stiffness { get; set; }
+        [field: SerializeField] public float Drag { get; set; }
+        [field: SerializeField] public Vector3 GravityDir { get; set; }
+        [field: SerializeField] public float GravityPower { get; set; }
+        [field: SerializeField] public float HitRadius { get; set; }
+        [field: SerializeField] public bool IsRoot { get; set; }
     }
 }

--- a/Runtime/Scripts/SpringBoneJointComponent.cs.meta
+++ b/Runtime/Scripts/SpringBoneJointComponent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a7de70457848fc141869fe20b54ffdbb

--- a/Runtime/Scripts/SpringBoneUtils.cs
+++ b/Runtime/Scripts/SpringBoneUtils.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using GLTFast.Schema;
+using UnityEngine;
+
+namespace GLTFast
+{
+    /// <summary>
+    /// Utility for applying DCL spring bone joint data to GameObjects.
+    /// </summary>
+    public static class SpringBoneUtils
+    {
+        /// <summary>
+        /// Applies spring bone joint components using the instantiator's node mapping.
+        /// </summary>
+        public static void ApplySpringBoneJoints(IGltfReadable gltf, Dictionary<uint, GameObject> nodes)
+        {
+            var sourceNodes = gltf.GetSourceRoot()?.nodes;
+            if (sourceNodes == null) return;
+
+            for (uint i = 0; i < sourceNodes.Length; i++)
+            {
+                var springBone = sourceNodes[i].extensions?.DCL_spring_bone_joint;
+                if (springBone == null) continue;
+
+                if (!nodes.TryGetValue(i, out var go)) continue;
+
+                ApplySpringBone(go, springBone);
+            }
+        }
+
+        /// <summary>
+        /// Applies spring bone joint components by matching node names in the scene hierarchy.
+        /// </summary>
+        public static void ApplySpringBoneJoints(IGltfReadable gltf, GameObject sceneRoot)
+        {
+            var sourceNodes = gltf.GetSourceRoot()?.nodes;
+            if (sourceNodes == null) return;
+
+            var transforms = sceneRoot.GetComponentsInChildren<Transform>(true);
+            var nameToTransform = new Dictionary<string, Transform>();
+            foreach (var t in transforms)
+                nameToTransform.TryAdd(t.name, t);
+
+            for (int i = 0; i < sourceNodes.Length; i++)
+            {
+                var springBone = sourceNodes[i].extensions?.DCL_spring_bone_joint;
+                if (springBone == null) continue;
+
+                var nodeName = sourceNodes[i].name ?? $"Node-{i}";
+                if (!nameToTransform.TryGetValue(nodeName, out var transform)) continue;
+
+                ApplySpringBone(transform.gameObject, springBone);
+            }
+        }
+
+        static void ApplySpringBone(GameObject go, SpringBoneJoint springBone)
+        {
+            var component = go.AddComponent<SpringBoneJointComponent>();
+            component.Stiffness = springBone.stiffness;
+            component.Drag = springBone.drag;
+            component.GravityDir = springBone.GravityDir;
+            component.GravityPower = springBone.gravityPower;
+            component.HitRadius = springBone.hitRadius;
+            component.IsRoot = springBone.isRoot;
+        }
+    }
+}

--- a/Runtime/Scripts/SpringBoneUtils.cs.meta
+++ b/Runtime/Scripts/SpringBoneUtils.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8f3a1b2c4d5e6f7089abcdef01234567


### PR DESCRIPTION
## Summary
- Add `DCL_spring_bone_joint` glTF node extension for spring bone simulation
- Parse spring bone data during glTF import and expose it as a `SpringBoneJointComponent` MonoBehaviour on the corresponding GameObjects
- Instantiation handled via `DclGameObjectInstantiator`, a subclass of `GameObjectInstantiator`