### PR TITLE
chore: Add PR merge alignment reminder

### DIFF
--- a/.github/workflows/pr-merge-reminder.yml
+++ b/.github/workflows/pr-merge-reminder.yml
@@ -1,0 +1,16 @@
+name: PR Merge Alignment Reminder
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  reminder:
+    uses: decentraland/actions/.github/workflows/pr-comment-reminder.yml@main
+    with:
+      message: |
+        ## 🔗 Merge Alignment Reminder
+
+        If this PR targets `main`, please make sure the corresponding changes in **[unity-explorer](https://github.com/decentraland/unity-explorer/)** are also ready to merge.
+
+        Both repos should be merged in coordination to avoid breaking changes. **Do not merge one without the other being ready.**


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that posts a merge alignment reminder comment on every newly opened PR.
- Uses the reusable `pr-comment-reminder` workflow from `decentraland/actions`.
- Reminds contributors to coordinate merges between `unity-gltf` and `unity-explorer` to avoid breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)